### PR TITLE
fix(postgres): Handling of the decimal column in the build query

### DIFF
--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -173,6 +173,9 @@ func jdbcGet(t ktType, idx int) string {
 		}
 		return fmt.Sprintf(`results.getObject(%d) as%s %s`, idx, nullCast, t.Name)
 	}
+	if t.IsBigDecimal() {
+		return fmt.Sprintf(`results.getBigDecimal(%d)`, idx)
+	}
 	return fmt.Sprintf(`results.get%s(%d)`, t.Name, idx)
 }
 
@@ -362,6 +365,10 @@ func (t ktType) IsInstant() bool {
 
 func (t ktType) IsUUID() bool {
 	return t.Name == "UUID"
+}
+
+func (t ktType) IsBigDecimal() bool {
+	return t.Name == "java.math.BigDecimal"
 }
 
 func makeType(req *plugin.GenerateRequest, col *plugin.Column) ktType {


### PR DESCRIPTION
fiix: https://github.com/sqlc-dev/sqlc-gen-kotlin/issues/18

## Problem
When creating a `decimal(19, 4)` column in PostgreSQL, it generates a data class with a property of type `java.math.BigDecimal?` .

However, when generating a query for a table with this column, the code `results.getjava.math.BigDecimal()` is produced. It seems that the correct code should be `results.getBigDecimal()` .