### PR TITLE
fix: Handle nullable enums

### DIFF
--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -79,9 +79,17 @@ func jdbcSet(t ktType, idx int, name string) string {
 	}
 	if t.IsEnum {
 		if t.Engine == "postgresql" {
-			return fmt.Sprintf("stmt.setObject(%d, %s.value, %s)", idx, name, "Types.OTHER")
+			if t.IsNull {
+				return fmt.Sprintf("stmt.setObject(%d, %s?.value, %s)", idx, name, "Types.OTHER")
+			} else {
+				return fmt.Sprintf("stmt.setObject(%d, %s.value, %s)", idx, name, "Types.OTHER")
+			}
 		} else {
-			return fmt.Sprintf("stmt.setString(%d, %s.value)", idx, name)
+			if t.IsNull {
+				return fmt.Sprintf("stmt.setString(%d, %s?.value)", idx, name)
+			} else {
+				return fmt.Sprintf("stmt.setString(%d, %s.value)", idx, name)
+			}
 		}
 	}
 	if t.IsArray {
@@ -155,7 +163,11 @@ func jdbcGet(t ktType, idx int) string {
 		return fmt.Sprintf(`(results.getArray(%d).array as Array<String>).map { v -> %s.lookup(v)!! }.toList()`, idx, t.Name)
 	}
 	if t.IsEnum {
-		return fmt.Sprintf("%s.lookup(results.getString(%d))!!", t.Name, idx)
+		if t.IsNull {
+			return fmt.Sprintf("%s.lookup(results.getString(%d))", t.Name, idx)
+		} else {
+			return fmt.Sprintf("%s.lookup(results.getString(%d))!!", t.Name, idx)
+		}
 	}
 	if t.IsArray {
 		return fmt.Sprintf(`(results.getArray(%d).array as Array<%s>).toList()`, idx, t.Name)

--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -104,11 +104,7 @@ func jdbcSet(t ktType, idx int, name string) string {
 	if t.IsUUID() {
 		return fmt.Sprintf("stmt.setObject(%d, %s)", idx, name)
 	}
-	if t.IsNull && t.PrimitiveType != "" {
-		return fmt.Sprintf("if (%[3]s != null) stmt.set%[1]s(%[2]d, %[3]s) else stmt.setNull(%[2]d, Types.%[4]s)", t.Name, idx, name, t.PrimitiveType)
-	} else {
-		return fmt.Sprintf("stmt.set%s(%d, %s)", t.Name, idx, name)
-	}
+	return fmt.Sprintf("stmt.set%s(%d, %s)", t.Name, idx, name)
 }
 
 type Params struct {
@@ -336,13 +332,12 @@ func BuildDataClasses(conf Config, req *plugin.GenerateRequest) []Struct {
 }
 
 type ktType struct {
-	Name          string
-	IsEnum        bool
-	IsArray       bool
-	IsNull        bool
-	PrimitiveType string
-	DataType      string
-	Engine        string
+	Name     string
+	IsEnum   bool
+	IsArray  bool
+	IsNull   bool
+	DataType string
+	Engine   string
 }
 
 func (t ktType) String() string {
@@ -391,13 +386,12 @@ func (t ktType) IsBigDecimal() bool {
 func makeType(req *plugin.GenerateRequest, col *plugin.Column) ktType {
 	typ, isEnum := ktInnerType(req, col)
 	return ktType{
-		Name:          typ,
-		IsEnum:        isEnum,
-		IsArray:       col.IsArray,
-		IsNull:        !col.NotNull,
-		PrimitiveType: ktPrimitiveType(typ),
-		DataType:      sdk.DataType(col.Type),
-		Engine:        req.Settings.Engine,
+		Name:     typ,
+		IsEnum:   isEnum,
+		IsArray:  col.IsArray,
+		IsNull:   !col.NotNull,
+		DataType: sdk.DataType(col.Type),
+		Engine:   req.Settings.Engine,
 	}
 }
 
@@ -410,25 +404,6 @@ func ktInnerType(req *plugin.GenerateRequest, col *plugin.Column) (string, bool)
 		return postgresType(req, col)
 	default:
 		return "Any", false
-	}
-}
-
-func ktPrimitiveType(t string) string {
-	switch t {
-	case "Int":
-		return "INTEGER"
-	case "Double":
-		return "DOUBLE"
-	case "Long":
-		return "BIGINT"
-	case "Short":
-		return "SMALLINT"
-	case "Float":
-		return "REAL"
-	case "Boolean":
-		return "BOOLEAN"
-	default:
-		return ""
 	}
 }
 

--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -96,7 +96,11 @@ func jdbcSet(t ktType, idx int, name string) string {
 	if t.IsUUID() {
 		return fmt.Sprintf("stmt.setObject(%d, %s)", idx, name)
 	}
-	return fmt.Sprintf("stmt.set%s(%d, %s)", t.Name, idx, name)
+	if t.IsNull && t.PrimitiveType != "" {
+		return fmt.Sprintf("if (%[3]s != null) stmt.set%[1]s(%[2]d, %[3]s) else stmt.setNull(%[2]d, Types.%[4]s)", t.Name, idx, name, t.PrimitiveType)
+	} else {
+		return fmt.Sprintf("stmt.set%s(%d, %s)", t.Name, idx, name)
+	}
 }
 
 type Params struct {
@@ -320,12 +324,13 @@ func BuildDataClasses(conf Config, req *plugin.GenerateRequest) []Struct {
 }
 
 type ktType struct {
-	Name     string
-	IsEnum   bool
-	IsArray  bool
-	IsNull   bool
-	DataType string
-	Engine   string
+	Name          string
+	IsEnum        bool
+	IsArray       bool
+	IsNull        bool
+	PrimitiveType string
+	DataType      string
+	Engine        string
 }
 
 func (t ktType) String() string {
@@ -374,12 +379,13 @@ func (t ktType) IsBigDecimal() bool {
 func makeType(req *plugin.GenerateRequest, col *plugin.Column) ktType {
 	typ, isEnum := ktInnerType(req, col)
 	return ktType{
-		Name:     typ,
-		IsEnum:   isEnum,
-		IsArray:  col.IsArray,
-		IsNull:   !col.NotNull,
-		DataType: sdk.DataType(col.Type),
-		Engine:   req.Settings.Engine,
+		Name:          typ,
+		IsEnum:        isEnum,
+		IsArray:       col.IsArray,
+		IsNull:        !col.NotNull,
+		PrimitiveType: ktPrimitiveType(typ),
+		DataType:      sdk.DataType(col.Type),
+		Engine:        req.Settings.Engine,
 	}
 }
 
@@ -392,6 +398,25 @@ func ktInnerType(req *plugin.GenerateRequest, col *plugin.Column) (string, bool)
 		return postgresType(req, col)
 	default:
 		return "Any", false
+	}
+}
+
+func ktPrimitiveType(t string) string {
+	switch t {
+	case "Int":
+		return "INTEGER"
+	case "Double":
+		return "DOUBLE"
+	case "Long":
+		return "BIGINT"
+	case "Short":
+		return "SMALLINT"
+	case "Float":
+		return "REAL"
+	case "Boolean":
+		return "BOOLEAN"
+	default:
+		return ""
 	}
 }
 

--- a/internal/tmpl/ktmodels.tmpl
+++ b/internal/tmpl/ktmodels.tmpl
@@ -19,7 +19,7 @@ enum class {{.Name}}(val value: String) {
 
   companion object {
     private val map = {{.Name}}.values().associateBy({{.Name}}::value)
-    fun lookup(value: String) = map[value]
+    fun lookup(value: String?) = map[value]
   }
 }
 {{end}}


### PR DESCRIPTION
When an enum is nullable, update the kotlin code to handle those cases.

Fixes: #26 

### Details

- When accessing the `value` of a nullable enum function parameter, use `?.` instead of `.`. Using `.` is a compile error
- When looking up the enum value from a string, since the column is nullable, `getString(..)` can return null. Update `lookup(..)` to allow null values.
- If the enum lookup returns a null value, do not use `!!` on it

### Appendix

- https://github.com/Piszmog/sqlc-gen-kotlin/pull/1
  - Examples updated based on this PR