### PR TITLE
fix: Postgres BigDecimal

### DIFF
--- a/internal/core/gen.go
+++ b/internal/core/gen.go
@@ -368,7 +368,7 @@ func (t ktType) IsUUID() bool {
 }
 
 func (t ktType) IsBigDecimal() bool {
-	return t.Name == "java.math.BigDecimal"
+	return t.Name == "BigDecimal"
 }
 
 func makeType(req *plugin.GenerateRequest, col *plugin.Column) ktType {

--- a/internal/core/imports.go
+++ b/internal/core/imports.go
@@ -86,6 +86,9 @@ func (i *Importer) modelImports() [][]string {
 	if i.usesType("UUID") {
 		std["java.util.UUID"] = struct{}{}
 	}
+	if i.usesType("BigDecimal") {
+		std["java.math.BigDecimal"] = struct{}{}
+	}
 
 	stds := make([]string, 0, len(std))
 	for s := range std {
@@ -119,6 +122,9 @@ func stdImports(uses func(name string) bool) map[string]struct{} {
 	}
 	if uses("UUID") {
 		std["java.util.UUID"] = struct{}{}
+	}
+	if uses("BigDecimal") {
+		std["java.math.BigDecimal"] = struct{}{}
 	}
 
 	return std

--- a/internal/core/postgresql_type.go
+++ b/internal/core/postgresql_type.go
@@ -36,7 +36,7 @@ func postgresType(req *plugin.GenerateRequest, col *plugin.Column) (string, bool
 		return "Float", false
 
 	case "pg_catalog.numeric":
-		return "java.math.BigDecimal", false
+		return "BigDecimal", false
 
 	case "bool", "pg_catalog.bool":
 		return "Boolean", false


### PR DESCRIPTION
Import `java.math.BigDecimal` instead of using explict path when using it.

Fixes: #28

### Details

- Update the postgres types to just be `BigDecimal` instead of `java.math.BigDecimal`
- Import `java.math.BigDecimal` when using big decimal

### Appendix

- https://github.com/Piszmog/sqlc-gen-kotlin/pull/2
  - Examples updated based on this PR